### PR TITLE
GenerateBlurhashMetadata.php: Supress imagescale errors

### DIFF
--- a/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
+++ b/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
@@ -98,7 +98,7 @@ class GenerateBlurhashMetadata implements IEventListener {
 			$newX = intval($currX * $newY / $currY);
 		}
 
-		$newImage = imagescale($image, $newX, $newY);
+		$newImage = @imagescale($image, $newX, $newY);
 		return ($newImage !== false) ? $newImage : $image;
 	}
 


### PR DESCRIPTION
Suppress errors in `GenerateBlurhashMetadata::resizedImageFromFile(...)` `imagescale `during file-scans:
Most of these errors are caused by out of range x/y-dims.

Triggering un unhandled exception, metadata-generation aborts at this point  (e.g. occ files:scan --generate-metadata), effectively preventing these images from being added to photos or maps.

This problem might be the root cause for an issue described in [nextcloud/photos](https://github.com/nextcloud/photos/issues/2768).

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
